### PR TITLE
ScalaHadoop exit code

### DIFF
--- a/src/main/scala/com/asimma/ScalaHadoop/ScalaHadoop.scala
+++ b/src/main/scala/com/asimma/ScalaHadoop/ScalaHadoop.scala
@@ -19,7 +19,7 @@ import org.apache.hadoop.conf.Configured
 import org.apache.hadoop.util.{ToolRunner, Tool}
 
 abstract class ScalaHadoop extends Configured with Tool {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Int = {
     ToolRunner.run(this, args)
   }
 }

--- a/src/main/scala/com/asimma/ScalaHadoop/ScalaHadoop.scala
+++ b/src/main/scala/com/asimma/ScalaHadoop/ScalaHadoop.scala
@@ -18,9 +18,11 @@ package com.asimma.ScalaHadoop
 import org.apache.hadoop.conf.Configured
 import org.apache.hadoop.util.{ToolRunner, Tool}
 
-abstract class ScalaHadoop extends Configured with Tool {
-  def main(args: Array[String]): Int = {
-    ToolRunner.run(this, args)
+abstract class ScalaHadoop extends Configured with Tool with Logging {
+  def main(args: Array[String]) {
+    val exitCode = ToolRunner.run(this, args)
+    debug("Hadoop job completed with exit code = " + exitCode)
+    System.exit(exitCode)
   }
 }
 


### PR DESCRIPTION
ScalaHadoop main method now returns ToolRunner exit code via System.exit. This exit code can be utilised by applications running ScalaHadoop as a JAR file.
